### PR TITLE
feat(login): Changed login to buttons for each API call

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,14 @@
-import Login from "./components/Login";
-import Main from "./components/Main-window";
-import "./App.css";
+import Login from "./components/Login"
+import Main from "./components/Main-window"
+import './App.css'
 
 function App() {
   return (
     <>
-      {true? <Main /> : <Login />}
+      {false ? <Main /> : <Login />}
 
     </>
   )
 }
 
-export default App;
+export default App

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,67 +1,14 @@
-import {useState} from "react"
 import "./Login.css"
 
 function Login() {
-  const [loginPage, setLoginPage] = useState(false);
-  const [formData, setFormData] = useState({
-    email: "",
-    password: "",
-    confirmPassword: ""
-  });
-
-  function handleChange(event){
-    const {name, value} = event.target
-        setFormData(prevFormData => ({
-            ...prevFormData,
-            [name]: value
-    }))
-  }
-
-  function handleLogin(event){
-    event.preventDefault();
-    console.log(formData)
-  }
-
-  function handleSignUp(event){
-    event.preventDefault();
-    console.log(formData)
-  }
-
-  function signUpPage(){
-    setLoginPage(true);
-  }
 
   return (
     <div className='container-fluid d-flex align-items-center justify-content-center h-100'>
         <div className='login d-flex align-items-center flex-column'>
-            <h1 className="login-header">{loginPage ? "Sign Up" : "Login"}</h1>
-            <form className="d-flex flex-column login-form" onSubmit={loginPage ? handleLogin : handleSignUp}>
-              <input 
-                type="email"
-                name="email" 
-                placeholder="Email address"
-                onChange={handleChange}
-                value={formData.email}
-              />
-              <input 
-                type="password"
-                name="password" 
-                placeholder="Password"
-                onChange={handleChange}
-                value={formData.password}
-              />
-              {loginPage && 
-                <input 
-                  type="password"
-                  name="confirmPassword"
-                  placeholder="Confirm password"
-                  onChange={handleChange}
-                  value={formData.confirmPassword}
-                />
-              }
-              <button className="login-button">{loginPage ? "Sign Up" : "Sign in"}</button>
-              {!loginPage && <p className="align-self-center signup-text" onClick={signUpPage}>Sign up</p>}
-            </form>
+            <h1 className="login-header">Login to account:</h1>
+              <button className="login-button">Connect Spotify Account</button>
+              <button className="login-button">Connect SoundCloud Account</button>
+              <button className="login-button">Connect ITunes Account</button>
         </div>
     </div>
   )


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Changed login to be three buttons

## Purpose
After researching the Spotify API I realized that the login credentials are not needed since the APIs will authorize users by popping up their own window when prompted

## Approach
Users will now be able to choose which API to use as well as not worry about email and passwords being stored on the app

## Learning
[Spotify API](https://developer.spotify.com/documentation/web-api/tutorials/code-pkce-flow)

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #25 
