### PR TITLE
38 user playlist api call

### DIFF
--- a/src/Context.jsx
+++ b/src/Context.jsx
@@ -8,6 +8,7 @@ function ContextProvider({ children }) {
     const [refreshToken, setRefreshToken] = useState('');
     const [expiresIn, setExpiresIn] = useState('');
     const [userProfileSpotify, setUserProfileSpotify] = useState({});
+    const [userPlaylistSpotify, setUserPlaylistSpotify] = useState({});
     const clientId = '146d22c1a56f4060939214df2f8b8ab4';
     const redirectUri = 'http://localhost:5173/callback';
 
@@ -104,6 +105,18 @@ function ContextProvider({ children }) {
         setUserProfileSpotify(data);
     }
 
+    async function getProfilePlaylist(accessToken) {
+        const response = await fetch('https://api.spotify.com/v1/me/playlists', {
+            headers: {
+                Authorization: 'Bearer ' + accessToken
+            }
+        });
+
+        const data = await response.json();
+        console.log(data);
+        setUserPlaylistSpotify(data);
+    }
+
     useEffect(() => {
         // Check if the current URL contains the authorization code and state
         const params = new URLSearchParams(window.location.search);
@@ -112,15 +125,16 @@ function ContextProvider({ children }) {
 
         if (authorizationCode && state) {
             // Verify the state if needed
-
             // Exchange the authorization code for an access token
             exchangeAuthorizationCode(authorizationCode);
         }
     }, []);
 
+    //retrieve Spotify data
     useEffect(() => {
         if (accessToken) {
             getProfile(accessToken);
+            getProfilePlaylist(accessToken);
         }
     }, [accessToken]);
 
@@ -160,7 +174,7 @@ function ContextProvider({ children }) {
     }, [refreshToken,expiresIn]);
 
     return (
-        <Context.Provider value={{ accessToken, userProfileSpotify, loginSpotify }}>
+        <Context.Provider value={{ accessToken, userProfileSpotify, userPlaylistSpotify, loginSpotify }}>
             {children}
         </Context.Provider>
     )


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Refresh token
2. User playlists

## Purpose
Added functionality to the refresh token so when the access token is about to expire the refresh token is used to update the access without user needed to login back in. Also added API call to retrieve the users playlist and store into state. 

## Approach
User now doesn't need to login every time the access token expires

## Learning
[refresh token](https://www.youtube.com/watch?v=Xcet6msf3eE&list=WL&index=1&t=1440s)
[user playlist](https://developer.spotify.com/documentation/web-api/reference/get-a-list-of-current-users-playlists)

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #38 
