### PR TITLE
62 display music from local storage

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -12,8 +12,7 @@ import "./Card.css"
  * @returns {ReactComponentElement} A Card meant to display relevant
  * information of a playlist/song
  */
-function Card({ coverArt, metaData, cardClickHandler}) {
-
+function Card({ coverArt, metaData, cardClickHandler }) {
     return (
         <div
             onClick={cardClickHandler}

--- a/src/components/Main-window.jsx
+++ b/src/components/Main-window.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useContext } from "react";
+import { useState, useEffect, useContext } from "react";
 
 import { Context } from "../contexts/Context.jsx"
 import { MusicPlayerStateContext } from "../contexts/MusicPlayerStateContext.jsx"
@@ -15,6 +15,8 @@ function Main() {
   console.log("render")
 
   const { userPlaylistSpotify } = useContext(Context)
+  const [localPlaylists, setLocalPlaylists] = useState(fetchLocalPlaylists());
+
   const {
     library,
     setLibrary,
@@ -24,10 +26,17 @@ function Main() {
   // Load the user's playlists from Spotify into the library whenever
   // it's updated
   useEffect(() => {
-    if (userPlaylistSpotify.items) {
+    if (localPlaylists && userPlaylistSpotify.items) {
+      const joinedPlaylists = [...userPlaylistSpotify.items, ...localPlaylists];
+      setLibrary(joinedPlaylists)
+    } else if (userPlaylistSpotify.items) {
       setLibrary(userPlaylistSpotify.items)
     }
-  }, [userPlaylistSpotify])
+  }, [userPlaylistSpotify, localPlaylists])
+
+  function fetchLocalPlaylists() {
+    return JSON.parse(localStorage.getItem("Local Music"));
+  }
 
   return (
     <div className="container-fluid h-100">

--- a/src/components/PlaylistContainer.jsx
+++ b/src/components/PlaylistContainer.jsx
@@ -18,7 +18,6 @@ function PlaylistContainer({ playlist }) {
     const { getSpotifyPlaylistTracks, currentPlaylistId } = useContext(Context)
     const { library, playlistIndex } = useContext(MusicPlayerStateContext)
     const [songCards, setSongCards] = useState([])
-
     // If playlist is from spotify, fetch the tracklist
     useEffect(() => {
         currentPlaylistId(playlist.id)
@@ -33,6 +32,15 @@ function PlaylistContainer({ playlist }) {
                                 song={song.track}
                             />
                     )))
+        }
+        if (playlist.source === 'local') {
+            setSongCards(playlist.tracks.map(
+                (song, index) =>
+                    <SongCard
+                        key={index}
+                        index={index}
+                        song={song}
+                    />))
         }
     }, [library, playlistIndex])
 

--- a/src/components/SongCard.jsx
+++ b/src/components/SongCard.jsx
@@ -32,6 +32,9 @@ function SongCard({ song }) {
     }
 
     function getSongArt(song) {
+        if (typeof song.songImage === 'string') {
+            return song.songImage
+        }
         if (song.album &&
             song.album.images &&
             song.album.images.length > 0) {
@@ -47,6 +50,9 @@ function SongCard({ song }) {
      * @returns {string} A string of the artists for a track
      */
     function getArtists(song) {
+        if (typeof song.artist === 'string') {
+            return song.artist
+        }
         if (song.artists &&
             song.artists.length > 0) {
             return song.artists.map(artist => artist.name)


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Now displays local playlists as well as its tracks.
2. Reduced the size of playlist and track songs images by compressing the uploaded files.

## Purpose
The local playlists were being saved into local storage but weren't being displayed.

## Approach
Modified the components created for displaying the Spotify playlists and tracks to allow for displaying the local playlists.

## Learning
I learned a great deal on how to convert images and audio into a string, specifically in base64. 
I also learned about the limitation of size that comes with local storage.

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #62 
![Capture](https://github.com/missile720/music-player/assets/56931380/9d43abdf-f18c-44da-9293-8a4515dc7aff)

