### PR TITLE
feat(responsivity): added mobile view functionality

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 
 import Login from "./components/Login"
+import CurrentSongOffCanvas from "./components/CurrentSongOffCanvas"
 import Main from "./components/Main-window"
 import { Context } from "./contexts/Context"
 import "./App.css"
@@ -8,7 +9,10 @@ import "./App.css"
 function App() {
   const { accessToken } = useContext(Context);
 
-  return <>{accessToken ? <Main /> : <Login />}</>;
+  return <>
+      {accessToken ? <Main /> : <Login />}
+      <CurrentSongOffCanvas/>
+    </>;
 }
 
 export default App;

--- a/src/assets/fastforward.svg
+++ b/src/assets/fastforward.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" className="bi bi-fast-forward-circle" viewBox="0 0 16 16">
+    <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14Zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16Z" />
+    <path d="M4.271 5.055a.5.5 0 0 1 .52.038L8 7.386V5.5a.5.5 0 0 1 .79-.407l3.5 2.5a.5.5 0 0 1 0 .814l-3.5 2.5A.5.5 0 0 1 8 10.5V8.614l-3.21 2.293A.5.5 0 0 1 4 10.5v-5a.5.5 0 0 1 .271-.445Z" />
+</svg>

--- a/src/assets/play.svg
+++ b/src/assets/play.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" className="bi bi-play-circle" viewBox="0 0 16 16">
+    <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z" />
+    <path d="M6.271 5.055a.5.5 0 0 1 .52.038l3.5 2.5a.5.5 0 0 1 0 .814l-3.5 2.5A.5.5 0 0 1 6 10.5v-5a.5.5 0 0 1 .271-.445z" />
+</svg>

--- a/src/assets/return.svg
+++ b/src/assets/return.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
+    <!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com/ License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+    <path d="M48.5 224H40c-13.3 0-24-10.7-24-24V72c0-9.7 5.8-18.5 14.8-22.2s19.3-1.7 26.2 5.2L98.6 96.6c87.6-86.5 228.7-86.2 315.8 1c87.5 87.5 87.5 229.3 0 316.8s-229.3 87.5-316.8 0c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0c62.5 62.5 163.8 62.5 226.3 0s62.5-163.8 0-226.3c-62.2-62.2-162.7-62.5-225.3-1L185 183c6.9 6.9 8.9 17.2 5.2 26.2s-12.5 14.8-22.2 14.8H48.5z"/>
+</svg>

--- a/src/assets/rewind.svg
+++ b/src/assets/rewind.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" className="bi bi-skip-backward-circle" viewBox="0 0 16 16">
+    <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z" />
+    <path d="M11.729 5.055a.5.5 0 0 0-.52.038L8.5 7.028V5.5a.5.5 0 0 0-.79-.407L5 7.028V5.5a.5.5 0 0 0-1 0v5a.5.5 0 0 0 1 0V8.972l2.71 1.935a.5.5 0 0 0 .79-.407V8.972l2.71 1.935A.5.5 0 0 0 12 10.5v-5a.5.5 0 0 0-.271-.445z" />
+</svg>

--- a/src/components/CurrentSong.css
+++ b/src/components/CurrentSong.css
@@ -36,6 +36,9 @@ li {
   flex-direction: column;
   justify-content: center;
 }
-.current-song-container:active{
+.current-song-container-light:active{
   background-color: #dfe0e9;
+}
+.current-song-container-dark:active{
+  background-color: #df9710;
 }

--- a/src/components/CurrentSong.css
+++ b/src/components/CurrentSong.css
@@ -36,3 +36,6 @@ li {
   flex-direction: column;
   justify-content: center;
 }
+.current-song-container:active{
+  background-color: #dfe0e9;
+}

--- a/src/components/CurrentSong.jsx
+++ b/src/components/CurrentSong.jsx
@@ -9,7 +9,7 @@ function CurrentSong() {
     }
 
     return (
-        <div className="current-song-container">
+        <button className="current-song-container" data-bs-toggle="offcanvas" data-bs-target="#currentSongOffCanvas" aria-controls="currentSongOffCanvas">
             <div className="current-song-left-side col-6">
                 <div className="image-container col-4">
                     {/* Current Song picture */}
@@ -48,7 +48,7 @@ function CurrentSong() {
                     </svg>
                 </div>
             </div>
-        </div>
+        </button>
     )
 }
 

--- a/src/components/CurrentSong.jsx
+++ b/src/components/CurrentSong.jsx
@@ -9,14 +9,15 @@ function CurrentSong() {
     }
 
     return (
-        <button className="current-song-container" data-bs-toggle="offcanvas" data-bs-target="#currentSongOffCanvas" aria-controls="currentSongOffCanvas">
+        <div className="current-song-container" data-bs-toggle="offcanvas" data-bs-target="#currentSongOffCanvas" aria-controls="currentSongOffCanvas">
             <div className="current-song-left-side col-6">
                 <div className="image-container col-4">
                     {/* Current Song picture */}
                     <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" fill="currentColor" className="bi bi-file-earmark-music" viewBox="0 0 16 16">
                         <path d="M11 6.64a1 1 0 0 0-1.243-.97l-1 .25A1 1 0 0 0 8 6.89v4.306A2.572 2.572 0 0 0 7 11c-.5 0-.974.134-1.338.377-.36.24-.662.628-.662 1.123s.301.883.662 1.123c.364.243.839.377 1.338.377.5 0 .974-.134 1.338-.377.36-.24.662-.628.662-1.123V8.89l2-.5V6.64z" />
                         <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2zM9.5 3A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5v2z" />
-                    </svg>                </div>
+                    </svg>                
+                </div>
                 <div className="song-title-artist col-8">
                     <ul>
                         <li>Song </li>
@@ -48,7 +49,7 @@ function CurrentSong() {
                     </svg>
                 </div>
             </div>
-        </button>
+        </div>
     )
 }
 

--- a/src/components/CurrentSong.jsx
+++ b/src/components/CurrentSong.jsx
@@ -10,14 +10,14 @@ function CurrentSong() {
 
     return (
         <div className="current-song-container">
-            <div className="current-song-left-side col-3">
-                <div className="image-container col-2">
+            <div className="current-song-left-side col-6">
+                <div className="image-container col-4">
                     {/* Current Song picture */}
                     <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" fill="currentColor" className="bi bi-file-earmark-music" viewBox="0 0 16 16">
                         <path d="M11 6.64a1 1 0 0 0-1.243-.97l-1 .25A1 1 0 0 0 8 6.89v4.306A2.572 2.572 0 0 0 7 11c-.5 0-.974.134-1.338.377-.36.24-.662.628-.662 1.123s.301.883.662 1.123c.364.243.839.377 1.338.377.5 0 .974-.134 1.338-.377.36-.24.662-.628.662-1.123V8.89l2-.5V6.64z" />
                         <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2zM9.5 3A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5v2z" />
                     </svg>                </div>
-                <div className="song-title-artist col-10">
+                <div className="song-title-artist col-8">
                     <ul>
                         <li>Song </li>
                         <li>Title</li>
@@ -26,7 +26,7 @@ function CurrentSong() {
                 </div>
             </div>
 
-            <div className="current-song-right-side col-4">
+            <div className="current-song-right-side col-6">
                 <div className="song-bar">
                     <input type="range" min="1" max="100" step="1" value={percentage} onChange={changePercent} id="range" className="custom-range" />
                 </div>

--- a/src/components/CurrentSong.jsx
+++ b/src/components/CurrentSong.jsx
@@ -1,15 +1,17 @@
-import { useState } from "react"
+import { useState, useContext } from "react"
+import { ThemeContext } from "../contexts/ThemeContext.jsx";
 import './CurrentSong.css'
 
 function CurrentSong() {
     const [percentage, setPercentage] = useState(10)
+    const { theme } = useContext(ThemeContext)
     
     function changePercent(event) {
         setPercentage(event.target.value)
     }
 
     return (
-        <div className="current-song-container" data-bs-toggle="offcanvas" data-bs-target="#currentSongOffCanvas" aria-controls="currentSongOffCanvas">
+        <div className={`current-song-container current-song-container-${theme}`} data-bs-toggle="offcanvas" data-bs-target="#currentSongOffCanvas" aria-controls="currentSongOffCanvas">
             <div className="current-song-left-side col-6">
                 <div className="image-container col-4">
                     {/* Current Song picture */}

--- a/src/components/CurrentSongOffCanvas.css
+++ b/src/components/CurrentSongOffCanvas.css
@@ -6,4 +6,5 @@
     width:70%;
     background-color:#dfe0e9;
     padding:1rem;
+    border-radius: 0.5rem;
 }

--- a/src/components/CurrentSongOffCanvas.css
+++ b/src/components/CurrentSongOffCanvas.css
@@ -1,0 +1,9 @@
+.song-pop-up{
+    background-color: #fff;
+    height: 80vh !important;
+}
+.offcanvas-art{
+    width:70%;
+    background-color:#dfe0e9;
+    padding:1rem;
+}

--- a/src/components/CurrentSongOffCanvas.jsx
+++ b/src/components/CurrentSongOffCanvas.jsx
@@ -1,0 +1,19 @@
+export default function CurrentSongOffCanvas(){
+    return(
+        <div 
+            className = "offcanvas offcanvas-bottom" 
+            id="currentSongOffCanvas" 
+            tabIndex="-1"
+            aria-labelledby="currentSongOffCanvasLabel"
+        >
+            <div className="offcanvas-header">
+                <h5 className="offcanvas-title" id="offcanvasLabel">Offcanvas</h5>
+                <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+            </div>
+            <div className="offcanvas-body">
+                Content for the offcanvas goes here. You can place just about any Bootstrap component or custom elements here.
+            </div>
+
+        </div>
+    )
+}

--- a/src/components/CurrentSongOffCanvas.jsx
+++ b/src/components/CurrentSongOffCanvas.jsx
@@ -1,17 +1,44 @@
+import {useState} from "react"
+import defaultCardArtImg from "../assets/defaultCardArt.svg"
+import rewindImg from "../assets/rewind.svg"
+import playImg from "../assets/play.svg"
+import fastforwardImg from "../assets/fastforward.svg"
+import "./CurrentSongOffCanvas.css"
+
+
+
 export default function CurrentSongOffCanvas(){
+    const [percentage, setPercentage] = useState(10)
+
+    function changePercent(event) {
+        setPercentage(event.target.value)
+    }
+
     return(
         <div 
-            className = "offcanvas offcanvas-bottom" 
+            className = "song-pop-up offcanvas offcanvas-bottom" 
             id="currentSongOffCanvas" 
             tabIndex="-1"
             aria-labelledby="currentSongOffCanvasLabel"
         >
-            <div className="offcanvas-header">
-                <h5 className="offcanvas-title" id="offcanvasLabel">Offcanvas</h5>
-                <button type="button" className="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+            <div className="offcanvas-header d-flex">
+                <button type="button" className="btn-close align-left" data-bs-dismiss="offcanvas" aria-label="Close">
+                </button>
             </div>
-            <div className="offcanvas-body">
-                Content for the offcanvas goes here. You can place just about any Bootstrap component or custom elements here.
+            <div className="offcanvas-body gap-2 d-flex flex-column align-items-center">
+                <img className = "offcanvas-art" src = {defaultCardArtImg}></img>
+                <div className = "song-data d-flex flex-column align-items-center">
+                    <h2 className = "m-0">Song Title</h2>
+                    <h3 className = "m-0">Artist</h3>
+                </div>
+                <div className="song-bar">
+                    <input type="range" min="1" max="100" step="1" value={percentage} onChange={changePercent} id="range" className="custom-range" />
+                </div>
+                <div className="music-play-buttons w-100 d-flex justify-content-evenly">
+                    <img src = {rewindImg}></img>
+                    <img src = {playImg}></img>
+                    <img src = {fastforwardImg}></img>
+                </div>
             </div>
 
         </div>

--- a/src/components/CurrentSongOffCanvas.jsx
+++ b/src/components/CurrentSongOffCanvas.jsx
@@ -38,10 +38,10 @@ export default function CurrentSongOffCanvas(){
                 <div className="song-bar">
                     <input type="range" min="1" max="100" step="1" value={percentage} onChange={changePercent} id="range" className="custom-range" />
                 </div>
-                <div className="music-play-buttons w-100 d-flex justify-content-evenly">
-                    <img className = {`button-${theme}`} src = {rewindImg}></img>
-                    <img className = {`button-${theme}`} src = {playImg}></img>
-                    <img className = {`button-${theme}`} src = {fastforwardImg}></img>
+                <div className="music-buttons w-100 d-flex justify-content-evenly">
+                    <img className = {`music-button-${theme}`} src = {rewindImg}></img>
+                    <img className = {`music-button-${theme}`} src = {playImg}></img>
+                    <img className = {`music-button-${theme}`} src = {fastforwardImg}></img>
                 </div>
             </div>
 

--- a/src/components/CurrentSongOffCanvas.jsx
+++ b/src/components/CurrentSongOffCanvas.jsx
@@ -1,13 +1,17 @@
-import {useState} from "react"
+import {useState, useContext} from "react"
+import { ThemeContext } from "../contexts/ThemeContext.jsx";
+
 import defaultCardArtImg from "../assets/defaultCardArt.svg"
 import rewindImg from "../assets/rewind.svg"
 import playImg from "../assets/play.svg"
 import fastforwardImg from "../assets/fastforward.svg"
+
 import "./CurrentSongOffCanvas.css"
 
 
 
 export default function CurrentSongOffCanvas(){
+    const { theme } = useContext(ThemeContext)
     const [percentage, setPercentage] = useState(10)
 
     function changePercent(event) {
@@ -21,11 +25,11 @@ export default function CurrentSongOffCanvas(){
             tabIndex="-1"
             aria-labelledby="currentSongOffCanvasLabel"
         >
-            <div className="offcanvas-header d-flex">
+            <div className={`offcanvas-header d-flex offcanvas-header-${theme}`}>
                 <button type="button" className="btn-close align-left" data-bs-dismiss="offcanvas" aria-label="Close">
                 </button>
             </div>
-            <div className="offcanvas-body gap-2 d-flex flex-column align-items-center">
+            <div className={`offcanvas-body gap-2 d-flex flex-column align-items-center offcanvas-body-${theme}`}>
                 <img className = "offcanvas-art" src = {defaultCardArtImg}></img>
                 <div className = "song-data d-flex flex-column align-items-center">
                     <h2 className = "m-0">Song Title</h2>
@@ -35,9 +39,9 @@ export default function CurrentSongOffCanvas(){
                     <input type="range" min="1" max="100" step="1" value={percentage} onChange={changePercent} id="range" className="custom-range" />
                 </div>
                 <div className="music-play-buttons w-100 d-flex justify-content-evenly">
-                    <img src = {rewindImg}></img>
-                    <img src = {playImg}></img>
-                    <img src = {fastforwardImg}></img>
+                    <img className = {`button-${theme}`} src = {rewindImg}></img>
+                    <img className = {`button-${theme}`} src = {playImg}></img>
+                    <img className = {`button-${theme}`} src = {fastforwardImg}></img>
                 </div>
             </div>
 

--- a/src/components/Main-window.jsx
+++ b/src/components/Main-window.jsx
@@ -9,7 +9,10 @@ import PlaylistContainer from "./PlaylistContainer";
 import SettingsBar from "./SettingsBar";
 import CurrentSong from "./CurrentSong";
 import FileUpload from "./FileUpload";
+
+import returnImg from "../assets/return.svg"
 import "./main.css";
+import Container from "./Container.jsx";
 
 function Main() {
   const { userPlaylistSpotify } = useContext(Context)
@@ -35,7 +38,7 @@ function Main() {
       <div className="row h-100">
 
         {/* left column */}
-        <div className= {`col-12 col-md-6 ${libraryView ? "":"d-none"}`}>
+        <div className= {`col-12 col-md-6 ${libraryView ? "":"d-none d-md-block"}`}>
           {/* Nav/search bar */}
           <div className="col-12 ns-bar text-center">
             <Nav />
@@ -62,9 +65,14 @@ function Main() {
         </div>
 
         {/* right column */}
-        <div className={`col-12 col-md-6 ${!libraryView ? "":"d-none"}`}>
-          <div className="col-12 cur-text">
-            <h3>{library.length > 0 && library[playlistIndex].name}</h3>
+        <div className={`col-12 col-md-6 ${!libraryView ? "":"d-none d-md-block"}`}>
+          <div className="col-12 d-flex">
+            <button className="col-3 d-md-none" onClick={()=>setLibraryView(true)}>
+              <img src={returnImg} alt = "Return arrow"></img>
+            </button>
+            <div className="col-9 col-md-12 cur-text">
+              <h3>{library.length > 0 && library[playlistIndex].name}</h3>
+            </div>
           </div>
           {/* Current playlist */}
           <div className="col-12 cur-list">

--- a/src/components/Main-window.jsx
+++ b/src/components/Main-window.jsx
@@ -31,8 +31,9 @@ function Main() {
     <div className="container-fluid h-100">
       <FileUpload />
       <div className="row h-100">
+
         {/* left column */}
-        <div className="col-6">
+        <div className="col-12 col-md-6 d-none d-md-block">
           {/* Nav/search bar */}
           <div className="col-12 ns-bar text-center">
             <Nav />
@@ -59,7 +60,7 @@ function Main() {
         </div>
 
         {/* right column */}
-        <div className="col-6">
+        <div className="col-12 col-md-6">
           <div className="col-12 cur-text">
             <h3>{library.length > 0 && library[playlistIndex].name}</h3>
           </div>
@@ -75,6 +76,7 @@ function Main() {
             <CurrentSong />
           </div>
         </div>
+
       </div>
     </div>
   );

--- a/src/components/Main-window.jsx
+++ b/src/components/Main-window.jsx
@@ -79,7 +79,7 @@ function Main() {
         {/* right column */}
         <div className={`col-12 col-md-6 ${!libraryView ? "":"d-none d-md-block"}`}>
           <div className="col-12 d-flex">
-            <button className="col-3 d-md-none" onClick={()=>setLibraryView(true)}>
+            <button className={`col-3 d-md-none button-${theme}`} onClick={()=>setLibraryView(true)}>
               <img src={returnImg} alt = "Return arrow"></img>
             </button>
             <div className="col-9 col-md-12 cur-text">

--- a/src/components/Main-window.jsx
+++ b/src/components/Main-window.jsx
@@ -16,7 +16,9 @@ function Main() {
   const {
     library,
     setLibrary,
-    playlistIndex
+    playlistIndex,
+    libraryView,
+    setLibraryView
   } = useContext(MusicPlayerStateContext)
 
   // Load the user's playlists from Spotify into the library whenever
@@ -33,7 +35,7 @@ function Main() {
       <div className="row h-100">
 
         {/* left column */}
-        <div className="col-12 col-md-6 d-none d-md-block">
+        <div className= {`col-12 col-md-6 ${libraryView ? "":"d-none"}`}>
           {/* Nav/search bar */}
           <div className="col-12 ns-bar text-center">
             <Nav />
@@ -60,7 +62,7 @@ function Main() {
         </div>
 
         {/* right column */}
-        <div className="col-12 col-md-6">
+        <div className={`col-12 col-md-6 ${!libraryView ? "":"d-none"}`}>
           <div className="col-12 cur-text">
             <h3>{library.length > 0 && library[playlistIndex].name}</h3>
           </div>

--- a/src/components/Main-window.jsx
+++ b/src/components/Main-window.jsx
@@ -12,7 +12,6 @@ import FileUpload from "./FileUpload";
 
 import returnImg from "../assets/return.svg"
 import "./main.css";
-import Container from "./Container.jsx";
 
 function Main() {
   const { userPlaylistSpotify } = useContext(Context)

--- a/src/components/main.css
+++ b/src/components/main.css
@@ -81,7 +81,6 @@
 .music-button-dark{
     filter: invert(93%) sepia(4%) saturate(22%) hue-rotate(79deg) brightness(112%) contrast(96%);
 }
-
   
 
 .lib-list {

--- a/src/components/main.css
+++ b/src/components/main.css
@@ -58,6 +58,23 @@
     background-color: #e09200;
     border: 2px solid #fafafa;
 }
+
+.offcanvas-header-light{
+    background-color: #d4d4d4;
+    color: #323130;
+}
+.offcanvas-header-dark{
+    background-color: #e09200;
+    color: #fafafa;
+}
+.offcanvas-body-light{
+    background-color: #d4d4d4;
+    color: #323130;
+}
+.offcanvas-body-dark{
+    background-color: #e09200;
+    color: #fafafa;
+}
   
   
 

--- a/src/components/main.css
+++ b/src/components/main.css
@@ -75,7 +75,13 @@
     background-color: #e09200;
     color: #fafafa;
 }
-  
+.music-button-light{
+    filter: invert(14%) sepia(7%) saturate(129%) hue-rotate(349deg) brightness(91%) contrast(84%);
+}
+.music-button-dark{
+    filter: invert(93%) sepia(4%) saturate(22%) hue-rotate(79deg) brightness(112%) contrast(96%);
+}
+
   
 
 .lib-list {

--- a/src/contexts/MusicPlayerStateContext.jsx
+++ b/src/contexts/MusicPlayerStateContext.jsx
@@ -6,6 +6,7 @@ function MusicPlayerStateContextProvider({ children }) {
     const [library, setLibrary] = useState([])
     const [playlistIndex, setPlaylistIndex] = useState(0)
     const [songIndex, setSongIndex] = useState(-1)
+    const [libraryView, setLibraryView] = useState(true)
 
     /**
      * Sets the current playlist index of the music player, also
@@ -15,6 +16,7 @@ function MusicPlayerStateContextProvider({ children }) {
     function choosePlaylist(index) {
         setPlaylistIndex(index)
         setSongIndex(-1)
+        setLibraryView(false)
     }
 
     /**
@@ -34,7 +36,9 @@ function MusicPlayerStateContextProvider({ children }) {
                 choosePlaylist,
                 songIndex,
                 setSongIndex,
-                chooseSong
+                chooseSong,
+                libraryView,
+                setLibraryView
             }}
         >
             {children}


### PR DESCRIPTION
## Changes
1. Added responsivity for mobile breakpoints
2. Added offcanvas to display CurrentSong
3. Adjusted styling to account for theme context

## Purpose
Add mobile responsivity

## Approach
Used bootstrap breakpoints to display app in a mobile friendly manner, and added new components to display

## Learning
Originally studied React-Router, to handle mobile view as seperate router elements, but opted for bootstrap breakpoints with a statehook to reduce complexity. 

## Preview
![image](https://github.com/missile720/music-player/assets/123608768/7e7337ee-a689-4058-a2c9-4f071c536ea8)
![image](https://github.com/missile720/music-player/assets/123608768/2ff5725e-b8d0-4f12-b5b7-c060ca202d29)
![image](https://github.com/missile720/music-player/assets/123608768/43117674-ddc0-4001-a6ea-9ad86b173f59)


Closes #068
