### PR TITLE
90 create a separate audio player for locally made playlists

### DIFF
--- a/src/components/LocalMusicPlayer.jsx
+++ b/src/components/LocalMusicPlayer.jsx
@@ -1,0 +1,10 @@
+
+const LocalMusicPlayer = ({ song }) => {
+    return (
+        <>
+            <audio className="local-music-player" src={song} controls />
+        </>
+    )
+}
+
+export default LocalMusicPlayer

--- a/src/components/Main-window.jsx
+++ b/src/components/Main-window.jsx
@@ -14,13 +14,14 @@ import PlaylistControls from "./PlaylistControls.jsx";
 
 import returnImg from "../assets/return.svg";
 import "./main.css";
+import LocalMusicPlayer from "./LocalMusicPlayer.jsx";
 
 function Main() {
   const { theme, mode } = useContext(ThemeContext);
-  const { userPlaylistSpotify ,accessToken, getSpotifyPlaylistTracks} = useContext(Context);
+  const { userPlaylistSpotify, accessToken, getSpotifyPlaylistTracks } = useContext(Context);
   const [localPlaylistsState, setLocalPlaylistsState] = useState(() => fetchLocalPlaylists());
 
-  const { library, setLibrary, playlistIndex, libraryView, setLibraryView, currentSongIndex } =
+  const { library, setLibrary, playlistIndex, libraryView, setLibraryView, currentSongIndex, currentSongSource } =
     useContext(MusicPlayerStateContext);
 
   // Load the user's playlists from Spotify and local storage into the
@@ -92,12 +93,17 @@ function Main() {
           {/* Current song bar */}
           <div className='col-12 cur-song-bar '>
             {/* < CurrentSong /> */}
-            <Player
-            playlist={library.length > 0 ? library[playlistIndex] : []}
-            currentSongIndex={currentSongIndex}
-            accessToken = {accessToken}
-            getSpotifyPlaylistTracks = {getSpotifyPlaylistTracks}
-            />
+            {currentSongSource === 'spotify' ?
+              <Player
+                playlist={library.length > 0 ? library[playlistIndex] : []}
+                currentSongIndex={currentSongIndex}
+                accessToken={accessToken}
+                getSpotifyPlaylistTracks={getSpotifyPlaylistTracks}
+              />
+              :
+              <LocalMusicPlayer />
+            }
+
           </div>
         </div>
       </div>

--- a/src/components/Main-window.jsx
+++ b/src/components/Main-window.jsx
@@ -105,9 +105,6 @@ function Main() {
             {currentSongSource === 'spotify' ?
               <Player
                 playlist={library.length > 0 ? library[playlistIndex] : []}
-                currentSongIndex={currentSongIndex}
-                accessToken={accessToken}
-                getSpotifyPlaylistTracks={getSpotifyPlaylistTracks}
               />
               :
               <LocalMusicPlayer />

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -1,34 +1,38 @@
-import React, { useEffect } from 'react'
+import { useState, useEffect, useContext } from 'react'
 import SpotifyPlayer from "react-spotify-web-playback"
+import { MusicPlayerStateContext } from "../contexts/MusicPlayerStateContext.jsx";
 
-import { useState } from "react"
 
-
-function Player({playlist, currentSongIndex, accessToken, getSpotifyPlaylistTracks}) {
+function Player({ playlist, currentSongIndex, accessToken, getSpotifyPlaylistTracks }) {
 
   const [volume, setVolume] = useState(.05)
-    const [currentSong, setCurrentSong] = useState('')
+  const [currentSong, setCurrentSong] = useState('')
 
-    useEffect(() => {
-      if (playlist.tracks && playlist.tracks.href) {
-        getSpotifyPlaylistTracks(playlist.tracks.href)
+  const { currentPlaylistSource } =
+    useContext(MusicPlayerStateContext);
+
+  useEffect(() => {
+    if (playlist.tracks && playlist.tracks.href) {
+      getSpotifyPlaylistTracks(playlist.tracks.href)
         .then(tracks =>
           setCurrentSong(tracks.items[currentSongIndex].track.uri)
-          )}
-}, [playlist, currentSongIndex])
+        )
+    }
+  }, [playlist, currentSongIndex])
 
   return (
     <div>
       <SpotifyPlayer
         name='Syntax Samurai Player'
-        styles={{ activeColor: '#fff',
-        // bgColor: '#333',
-        color: '#333',
-        loaderColor: '#fff',
-        sliderColor: '#1cb954',
-        // trackArtistColor: '#fff',
-        // trackNameColor: '#fff',
-      }}
+        styles={{
+          activeColor: '#fff',
+          // bgColor: '#333',
+          color: '#333',
+          loaderColor: '#fff',
+          sliderColor: '#1cb954',
+          // trackArtistColor: '#fff',
+          // trackNameColor: '#fff',
+        }}
         token={accessToken}
         layout='responsive'
         initialVolume={volume}
@@ -36,7 +40,7 @@ function Player({playlist, currentSongIndex, accessToken, getSpotifyPlaylistTrac
         play={true}
         persistDeviceSelection={false}
         uris={currentSongIndex == 0 ? playlist.uri : currentSong}
-/>
+      />
     </div>
   )
 }

--- a/src/contexts/MusicPlayerStateContext.jsx
+++ b/src/contexts/MusicPlayerStateContext.jsx
@@ -9,6 +9,7 @@ function MusicPlayerStateContextProvider({ children }) {
     const [libraryView, setLibraryView] = useState(true)
     const [songProgress, setSongProgress] = useState(10)
     const [currentSongIndex, setCurrentSongIndex] = useState(0)
+    const [currentSongSource, setCurrentSongSource] = useState('')
 
     // Effects
     /**
@@ -23,6 +24,15 @@ function MusicPlayerStateContextProvider({ children }) {
 
         return () => window.removeEventListener("resize", setAsLibraryView)
     }, [])
+
+    /**
+     * Side effect for setting the source of the currently selected song
+     */
+    useEffect(() => {
+        if (library[playlistIndex]) {
+            setCurrentSongSource(library[playlistIndex].source ? 'local' : 'spotify')
+        }
+    }, [currentSongIndex])
 
     // Functions
     /**
@@ -83,7 +93,8 @@ function MusicPlayerStateContextProvider({ children }) {
                 libraryView,
                 setLibraryView,
                 songProgress,
-                scrubSong
+                scrubSong,
+                currentSongSource
             }}
         >
             {children}

--- a/src/contexts/MusicPlayerStateContext.jsx
+++ b/src/contexts/MusicPlayerStateContext.jsx
@@ -32,7 +32,7 @@ function MusicPlayerStateContextProvider({ children }) {
         if (library[playlistIndex]) {
             setCurrentSongSource(library[playlistIndex].source ? 'local' : 'spotify')
         }
-    }, [currentSongIndex])
+    }, [songIndex])
 
     // Functions
     /**


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Created a very basic audio player to display a separate audio player when a song not sourced from Spotify is played.
2. Modified "MusicPlayerStateContext" to handle the source of a clicked song.

## Purpose
The Spotify audio player only plays songs from the Spotify API and won't be able to play songs that users upload.

## Approach
By checking the source of the songs clicked, we can switch between the Spotify audio player and our custom one.

## Learning
Researched into different audio libraries that we could use for playing the uploaded music.
![Capture](https://github.com/missile720/music-player/assets/56931380/2f9ff510-a780-4c13-98da-7b5e5cd070e2)


_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #90 
