### PR TITLE
fix(bug): Fixed bug when hitting next on SpotifyPlayer on last song in playlist

### DIFF
--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -42,9 +42,11 @@ function Player() {
           const nextIndex = prevIndex + 1
           return nextIndex < currentTracklist.length ? nextIndex : 0
         })
-      }
-
-      if (nextTracks && nextTracks.includes(lastUri)) {
+      } else if (previousTracks.length <= 0) {
+        // The specific case for if the user preses next on the last
+        // song on a playlist
+        setSongIndex(0)
+      } else if (nextTracks && nextTracks.includes(lastUri)) {
         setSongIndex(prevIndex => prevIndex - 1)
       }
     }

--- a/src/components/main.css
+++ b/src/components/main.css
@@ -197,8 +197,8 @@
 /* Reproportions Playlist view for mobile */
 @media (max-height: 988px) and (max-width: 767px) {
     .cur-list {
-        height: 70%;
-        max-height: 70vh;
+        height: 60%;
+        max-height: 60vh;
     }
 
     .cur-text {

--- a/src/contexts/MusicPlayerStateContext.jsx
+++ b/src/contexts/MusicPlayerStateContext.jsx
@@ -39,12 +39,17 @@ function MusicPlayerStateContextProvider({ children }) {
     // Functions
     /**
      * Sets the current playlist index of the music player, also
-     * reseting the song index
+     * reseting the song index. Also toggles the player to playlist
+     * view on mobile.
      * @param {Number} index The index of a playlist in the library
      */
     function choosePlaylist(index) {
-        setPlaylistIndex(index)
-        setSongIndex(0)
+        // Only change playlist index and reset song index when given
+        // a new songIndex
+        if (index !== playlistIndex) {
+            setSongIndex(0)
+            setPlaylistIndex(index)
+        }
 
         // Only allow user to go to playlist view on mobile
         if (typeof window !== "undefined" &&


### PR DESCRIPTION
## Changes
1. Added logic to songIndex updating useEffect in player component to account for when user hits next on the last song in a playlist.
2. Adjusted styling of the mobile view to account for the visualizer component.
3. Added new logic to not reset the songIndex if the user selects the playlistCard for the current playlist (for general usage, not meant to fix any specific bugs).

## Purpose
To add logic to account for when the user hits next on the last song of a playlist, as before the songIndex would simply increment instead of looping back to 0.

## Approach
Adding an extra else if into the logic of the useEffect allows us to account for this edge case.

Closes #099
