### PR TITLE
refactor(style): Refactored elements to account for non-theme related DS feedback 

### DIFF
--- a/frontend/src/components/Card.css
+++ b/frontend/src/components/Card.css
@@ -15,6 +15,7 @@
 
 .trashIcon {
     margin-left: auto;
+    height: 2rem;
 }
 
 .shared-code {

--- a/frontend/src/components/Player.jsx
+++ b/frontend/src/components/Player.jsx
@@ -1,10 +1,12 @@
-import { useState, useEffect, useContext } from 'react'
+import { useState, useEffect, useContext } from "react"
 import SpotifyPlayer, { spotifyApi } from "react-spotify-web-playback"
 
 import { Context } from "../contexts/Context"
 import { MusicPlayerStateContext } from "../contexts/MusicPlayerStateContext"
+import { SettingsStateContext } from "../contexts/SettingsStateContext"
 
-const INITIAL_VOLUME = .05;
+const PLAYER_NAME = "Syntax Samurai Player"
+const VOLUME_MAX = 100
 
 function Player() {
   const {
@@ -13,17 +15,26 @@ function Player() {
     currentTracklist
   } = useContext(MusicPlayerStateContext)
   const { accessToken, getSongAudioAnalysis } = useContext(Context)
+  const { volume } = useContext(SettingsStateContext)
+
+  const playerVolume = volume / VOLUME_MAX;
 
   // Used to track the react spotify player's playback state
-  const [playerCallback, setPlayerCallback] = useState("");
+  const [playerCallback, setPlayerCallback] = useState("")
 
   // Updates the songIndex as the user uses the previous and next buttons
   // on the react spotify player, properly updating the songCards in the
-  // playlistContainer.
+  // playlistContainer. Also grabs audio analaysis from the playback
+  // information for the Waveform Visualizer
   useEffect(() => {
-    getSongAudioAnalysis(playerCallback);
+    // Logic for Waveform Visualizer
+    // Only get song audio analysis if track data exists
+    if (playerCallback) {
+      getSongAudioAnalysis(playerCallback);
+    }
 
-    let currentUri = "";
+    // Logic for songIndex updating
+    let currentUri = ""
     if (playerCallback && playerCallback.track.uri) {
       currentUri = playerCallback.track.uri
     } else {
@@ -50,13 +61,20 @@ function Player() {
         setSongIndex(prevIndex => prevIndex - 1)
       }
     }
-
   }, [playerCallback])
+
+  useEffect(() => {
+    if (playerCallback) {
+      spotifyApi.getDevices(accessToken)
+        .then(res => res.devices.find(device => device.name === PLAYER_NAME))
+        .then(device => spotifyApi.setVolume(accessToken, volume, device.id))
+    }
+  }, [volume])
 
   return (
     <div className="d-flex justify-content-center flex-column align-items-center h-100">
       <SpotifyPlayer
-        name='Syntax Samurai Player'
+        name={PLAYER_NAME}
         styles={{
           activeColor: '#fff',
           // bgColor: '#333',
@@ -69,7 +87,7 @@ function Player() {
         callback={setPlayerCallback}
         token={accessToken}
         layout='responsive'
-        initialVolume={INITIAL_VOLUME}
+        initialVolume={playerVolume}
         inlineVolume={true}
         offset={songIndex}
         play={true}

--- a/frontend/src/components/Player.jsx
+++ b/frontend/src/components/Player.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from "react"
-import SpotifyPlayer, { spotifyApi } from "react-spotify-web-playback"
+import SpotifyPlayer from "react-spotify-web-playback"
 
 import { Context } from "../contexts/Context"
 import { MusicPlayerStateContext } from "../contexts/MusicPlayerStateContext"
@@ -62,14 +62,6 @@ function Player() {
       }
     }
   }, [playerCallback])
-
-  useEffect(() => {
-    if (playerCallback) {
-      spotifyApi.getDevices(accessToken)
-        .then(res => res.devices.find(device => device.name === PLAYER_NAME))
-        .then(device => spotifyApi.setVolume(accessToken, volume, device.id))
-    }
-  }, [volume])
 
   return (
     <div className="d-flex justify-content-center flex-column align-items-center h-100">

--- a/frontend/src/components/PlaylistCard.jsx
+++ b/frontend/src/components/PlaylistCard.jsx
@@ -46,12 +46,17 @@ function PlaylistCard({ playlist, index }) {
 
     const playlistArtURL = getPlaylistArt(playlist);
 
-    const playlistTitle = <h4>{playlist.name}</h4>
+    const playlistMetaData = <div>
+        <h4>{playlist.name}</h4>
+        <h5 className="fs-6 fst-italic fw-light">
+            {playlist.source ? "Local" : "Spotify"}
+        </h5>
+    </div>
 
     return (
         <Card
             coverArt={{ url: playlistArtURL, title: playlist.name }}
-            metaData={playlistTitle}
+            metaData={playlistMetaData}
             cardClickHandler={() => choosePlaylist(index)}
             cardType={getCardType(playlistIndex)}
         />

--- a/frontend/src/components/PlaylistContainer.jsx
+++ b/frontend/src/components/PlaylistContainer.jsx
@@ -15,7 +15,11 @@ import SongCard from "./SongCard"
  * elements for songs in a playlist
  */
 function PlaylistContainer({ playlist }) {
-    const { getSpotifyPlaylistTracks, currentPlaylistId } = useContext(Context)
+    const {
+        getSpotifyPlaylistTracks,
+        currentPlaylistId,
+        userProfileSpotify
+    } = useContext(Context)
     const {
         library,
         playlistIndex,
@@ -24,13 +28,42 @@ function PlaylistContainer({ playlist }) {
     } = useContext(MusicPlayerStateContext)
     const [songCards, setSongCards] = useState([])
 
-    // If playlist is from spotify, fetch the tracklist
+    /**
+     * Returns whether or not a playlist object is owned by the user
+     * and is therefore editable by the them. Used to check for rendering 
+     * logic of songCards.
+     * @param {Object[]} playlist An object containing the relevant
+     * informatino about a playlist
+     * @returns {bool} Whether or not a playlist is editable by a user
+     */
+    function isOwnedByUser(playlist) {
+        // If the playlist is from the user's local files, it is assumed
+        // they will always be editable
+        if (playlist.source && playlist.source === "local") {
+            return true
+        }
+
+        // If the playlist is from spotify
+        if (playlist.owner) {
+            return playlist.owner.uri === userProfileSpotify.uri
+        }
+
+        return true
+    }
+
+    // Set the songCards based on the source of the playlist
     useEffect(() => {
         currentPlaylistId(playlist.id)
 
+        const isEditable = isOwnedByUser(playlist)
+
+        // If the playlist is from spotify
         if (playlist.tracks && playlist.tracks.href) {
             getSpotifyPlaylistTracks(playlist.tracks.href)
                 .then(tracks => {
+
+                    // Only process songs in the playlist if they have valid
+                    // track information (i.e. are playable)
                     const validTracks = tracks.items.filter(song => song.track)
 
                     setCurrentTracklist(
@@ -45,12 +78,14 @@ function PlaylistContainer({ playlist }) {
                                 index={index}
                                 song={song.track}
                                 cardClickHandler={() => chooseSong(index)}
+                                isEditable={isEditable}
                             />
                         )
                     )
                 })
         }
 
+        // If the spotify is from local files
         if (playlist.source === 'local') {
             setSongCards(playlist.tracks.map(
                 (song, index) =>
@@ -59,6 +94,7 @@ function PlaylistContainer({ playlist }) {
                         index={index}
                         song={song}
                         cardClickHandler={() => chooseSong(index)}
+                        isEditable={isEditable}
                     />))
         }
     }, [library, playlistIndex])

--- a/frontend/src/components/Popover.jsx
+++ b/frontend/src/components/Popover.jsx
@@ -1,22 +1,47 @@
 /* eslint react/prop-types: 0 */
-import { useState, useEffect, useRef } from 'react'
+import {
+    useState,
+    useEffect,
+    useRef,
+    useContext
+} from 'react'
+
+import { MusicPlayerStateContext } from '../contexts/MusicPlayerStateContext';
+
 import VolumeComponent from './Volume'
 import EqualizerComponent from './Equalizer';
-import {Volume, Equalizer} from './icons';
+import { Volume, Equalizer } from './icons';
+
 import "./popover.css";
 
-const Popover = ({content}) => {
+const Popover = ({ content }) => {
+    const { currentSongSource } = useContext(MusicPlayerStateContext)
+
     const [isVisible, setIsVisible] = useState(false)
+    const [enabled, setEnabled] = useState(true)
     const popoverRef = useRef(null)
-   
 
     const handleToggle = () => {
         setIsVisible(true)
     }
 
+    console.log(currentSongSource)
+
+    const popoverClassName = () => {
+        let className = "popover "
+
+        if (!enabled) {
+            className += " disabled-popover"
+        }
+
+        return className
+    }
+
     useEffect(() => {
         const handleClickOutside = (event) => {
-            if (!isVisible && popoverRef.current && !popoverRef.current.contains(event.target)) {
+            if (!isVisible &&
+                popoverRef.current &&
+                !popoverRef.current.contains(event.target)) {
                 setIsVisible(false)
             }
         }
@@ -25,25 +50,37 @@ const Popover = ({content}) => {
         return () => {
             document.removeEventListener('mousedown', handleClickOutside)
         }
-            
+
     }, [])
-        
+
+    useEffect(() => {
+        // If the current song source is local, disables the popovers.
+        // Since the SpotifyPlayer disallows us from adjusting EQ
+        // and volume, this allows us to indicate to the user that they
+        // should use the SpotifyPlayer's volume controls instead of the
+        // SetttingBar's
+        setEnabled(currentSongSource === "local")
+    }, [currentSongSource])
+
     return (
-        <div className='popover' ref={popoverRef}>
+        <div
+            className={popoverClassName()}
+            ref={popoverRef}
+        >
             {content === 'volume' ?
                 isVisible ?
-                    <VolumeComponent className="popover-content volume"/>
-                : 
-                    <Volume handleClick={() => handleToggle()}  />
-                
+                    <VolumeComponent className="popover-content volume" />
+                    :
+                    <Volume handleClick={() => handleToggle()} />
+
                 :
                 isVisible ?
-                    <EqualizerComponent className="popover-content volume"/>
-                : 
-                    <Equalizer handleClick={() => handleToggle()}  />
-                
+                    <EqualizerComponent className="popover-content volume" />
+                    :
+                    <Equalizer handleClick={() => handleToggle()} />
+
             }
-            
+
         </div>
     )
 }

--- a/frontend/src/components/SongCard.jsx
+++ b/frontend/src/components/SongCard.jsx
@@ -14,13 +14,15 @@ import trashHover from "../assets/trashSelected.svg";
  * @param {Number} index The index of a song in the playlist
  * @param {func} cardClickHandler The function to be used as the onClick
  * handler for the SongCard
+ * @param {bool} isEditable bool for whether or not the user is able to
+ * edit the playlist the songs are from
  * @returns A Card component displaying the details of a
  * given song
  */
-function SongCard({ song, index, cardClickHandler }) {
+function SongCard({ song, index, cardClickHandler, isEditable }) {
   const [hover, setHover] = useState(false);
   const { deletePlaylistTrack, currentPlaylist } = useContext(Context)
-  const { chooseSong, songIndex } = useContext(MusicPlayerStateContext)
+  const { songIndex } = useContext(MusicPlayerStateContext)
 
   function handleMouseEnter() {
     setHover(true);
@@ -97,7 +99,8 @@ function SongCard({ song, index, cardClickHandler }) {
         <h4>{song.name}</h4>
         <h5>{getArtists(song)}</h5>
       </span>
-      <img
+
+      {isEditable && <img
         src={hover ? trashHover : trash}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
@@ -106,7 +109,7 @@ function SongCard({ song, index, cardClickHandler }) {
         }
         alt="trash icon"
         className="trashIcon"
-      />
+      />}
     </>
   );
 

--- a/frontend/src/components/Volume.jsx
+++ b/frontend/src/components/Volume.jsx
@@ -2,9 +2,7 @@ import { useContext } from "react";
 import { SettingsStateContext } from "../contexts/SettingsStateContext";
 
 const VolumeComponent = () => {
-    
-
-    const {volume, updateVolume} = useContext(SettingsStateContext)
+    const { volume, updateVolume } = useContext(SettingsStateContext)
 
     const handleVolumeChange = (event) => {
         const newVolume = parseInt(event.target.value)
@@ -22,12 +20,12 @@ const VolumeComponent = () => {
                 className="volume"
             />
             <div className="description">
-                <input 
+                <input
                     type="number"
-                    className="value" 
+                    className="value"
                     value={volume}
                     onChange={handleVolumeChange}
-                /> 
+                />
                 <p className="value value-text">Volume</p>
             </div>
         </div>

--- a/frontend/src/components/popover.css
+++ b/frontend/src/components/popover.css
@@ -14,6 +14,14 @@
     
 }
 
+/* 
+ * Used to disable the popovers when using SpotifyPlayer
+ */
+.disabled-popover {
+    pointer-events: none;
+    filter: invert(100%) sepia(0%) saturate(0%) hue-rotate(216deg) brightness(103%) contrast(103%)
+}
+
 .volume, .bass, .treble {
     transform: rotate(270deg);
     width: 80px;

--- a/frontend/src/contexts/Context.jsx
+++ b/frontend/src/contexts/Context.jsx
@@ -10,7 +10,7 @@ function ContextProvider({ children }) {
   const [userProfileSpotify, setUserProfileSpotify] = useState({});
   const [userPlaylistSpotify, setUserPlaylistSpotify] = useState({});
   const [currentPlaylist, setCurrentPlaylist] = useState("");
-  const [currentPlayingSongData,setCurrentPlayingSongData] = useState();
+  const [currentPlayingSongData, setCurrentPlayingSongData] = useState();
   const [currentPlayingSongCallback, setCurrentPlayingSongCallback] = useState();
   const clientId = "146d22c1a56f4060939214df2f8b8ab4";
   const redirectUri = "http://localhost:5173/callback";
@@ -134,7 +134,7 @@ function ContextProvider({ children }) {
 
   async function getSongAudioAnalysis(playerCallback) {
     let trackId = playerCallback.track.id;
-    
+
     const response = await fetch(`https://api.spotify.com/v1/audio-analysis/${trackId}`, {
       headers: {
         Authorization: "Bearer " + accessToken,


### PR DESCRIPTION
## Changes
1. Adjusted sizing of delete buttons on songCards based on feedback from DS intern meeting. Also added logic to only render them whenever the user has ownership of the playlist the songs are from (preventing the user from trying to use them on other people's Spotify playlists they have added to their library).
2. Added a source meta tag to playlistCards to specify if the playlist is from Spotify or is from their Local files.
3. Added logic to disable the EQ and Volume Popovers when the user is using the SpotifyPlayer, to indicate they are unusable for Spotify playback.

## Purpose
By adhering to the DS intern feedback we received, we improved the UX of our app by providing more information about our playlists and only providing users inputs for certain functionality when they are available.

## Approach
Adjusted styles to adhere to feedback given from the digital skills interns. Also added some extra logic for better user experience such as removal of delete buttons from other people's Spotify playlists, source metatag on playlistCards, and the disabling of the EQ and Volume popovers during Spotify playback to indicate they are unusable when listening to spotify.

## Learning
Originally, this issue was also meant to address linking the SettingsContext to the SpotifyPlayer. During the process of trying to implement these changes and read through more of the documentation however, we discovered roadblocks that prevented us from doing so. While reading through the [Spotify Web API](https://developer.spotify.com/documentation/web-api) and [Spotify Web Playback SDK](https://developer.spotify.com/documentation/web-playback-sdk), we found no mention of any endpoints available to adjust EQ from Spotify playback. And from multiple attempts to try and control the SpotifyPlayer's volume with our own external volume control and reading through the react-spotify-web-playback [documentation](https://www.npmjs.com/package/react-spotify-web-playback) and [code](https://github.com/gilbarbara/react-spotify-web-playback/tree/main), we discovered through an [issue posted in the GitHub repo](https://github.com/gilbarbara/react-spotify-web-playback/issues/28) that the creator of the package specifically disallows trying to control the volume of the player with external components.

## Preview
![image](https://github.com/missile720/music-player/assets/45379337/daf168db-3385-483b-a121-958b09e14532)
*Here, we can see a playlist not owned by the user will have its songCards render without the delete button, that different source meta tags will render on playlistCards based on their source, and that when listening to a Spotify playlist, the user will be unable to use the Volume and EQ Popovers*

Closes #105
