### PR TITLE
117 bug fix edit spotify playlist name

### DIFF
--- a/frontend/src/components/EditPlaylists.jsx
+++ b/frontend/src/components/EditPlaylists.jsx
@@ -22,6 +22,7 @@ const EditPlaylists = ({
           data-live-search="true"
           onChange={handleSelectionChange}
         >
+          <option value="none" selected disabled hidden>Select an Option</option>
           {playlistsToEditOptions}
         </select>
       </div>

--- a/frontend/src/components/Main-window.jsx
+++ b/frontend/src/components/Main-window.jsx
@@ -19,7 +19,7 @@ import LocalMusicPlayer from "./LocalMusicPlayer.jsx";
 
 // Debugging variables
 import testPlaylistsData from "../test/test-playlist.jsx";
-const debug = true;
+const debug = false;
 
 function Main() {
   const { theme, mode } = useContext(ThemeContext);

--- a/frontend/src/contexts/Context.jsx
+++ b/frontend/src/contexts/Context.jsx
@@ -211,6 +211,8 @@ function ContextProvider({ children }) {
     } catch (error) {
       console.log(error);
     }
+
+    getProfilePlaylist();
   }
 
   function addPlaylistTrack(playlistId, trackUri) {


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Fixed editing spotify playlist name so it updates in real time so user doesnt need to refresh page
2. Added select option to fix when default name doesnt change

## Purpose
User can now see changes happen in real time

## Approach
User doesnt need to login again to see changes to spotify playlist name

## Learning

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #117 
