### PR TITLE
fix(bug): Fixed Spotify playback bug and did miscellaneous styling for design consistency

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,11 @@ function App() {
   const { accessToken } = useContext(Context);
 
   return <>
+    {/* Main check for if login or main should load */}
     {accessToken ? <Main /> : <Login />}
+
+    {/* Offcanvas and modal components to be placed out
+        of flow of main page */}
     <CurrentSongOffCanvas />
     <LogoutPrompt />
   </>;

--- a/frontend/src/components/CurrentSong.css
+++ b/frontend/src/components/CurrentSong.css
@@ -4,6 +4,7 @@
   height: 100%;
   width: 100%;
   justify-content: space-evenly;
+  pointer-events: none;
 }
 
 .current-song-container:focus-within {
@@ -32,6 +33,7 @@ li {
 .music-play-buttons {
   display: flex;
   justify-content: space-between;
+  pointer-events: all;
 }
 
 .music-button {
@@ -86,6 +88,18 @@ li {
 
   .song-title {
     font-size: 1rem;
+  }
+
+  /**
+   * Added styling to only active modal when selecting
+   * non-play buttons
+   */
+  .current-song-container > .current-song-left-side {
+    pointer-events: auto;
+  }
+
+  .current-song-container > .music-play-buttons {
+    pointer-events: none;
   }
 
   .royal-light-current-song-container:active

--- a/frontend/src/components/CurrentSong.jsx
+++ b/frontend/src/components/CurrentSong.jsx
@@ -34,12 +34,14 @@ function CurrentSong() {
             className={`current-song-container 
                 ${theme}-${mode}-current-song-container 
                 px-1 pe-2 rounded`}
-            data-bs-toggle="offcanvas"
-            data-bs-target="#currentSongOffCanvas"
-            aria-controls="currentSongOffCanvas"
             disabled={libraryView}
         >
-            <div className="current-song-left-side col-8 col-md-6">
+            <div
+                className={`current-song-left-side col-8 col-md-6`}
+                data-bs-toggle="offcanvas"
+                data-bs-target="#currentSongOffCanvas"
+                aria-controls="currentSongOffCanvas"
+            >
                 <div className="image-container col-4 d-flex justify-content-center">
                     {/* Current Song picture */}
                     <img

--- a/frontend/src/components/LocalMusicPlayer.jsx
+++ b/frontend/src/components/LocalMusicPlayer.jsx
@@ -16,25 +16,29 @@ const LocalMusicPlayer = () => {
         songIndex,
         hasNonEmptyTracklist,
         nextTrack,
-        getDuration
+        getDuration,
+        hasValidSongIndex
     } = useContext(MusicPlayerStateContext)
     const { volume, VOLUME_MAX } = useContext(SettingsStateContext)
 
     return (
         <>
             <CurrentSong />
-            <ReactPlayer
-                height="0"
-                ref={getPlayer}
-                url={hasNonEmptyTracklist() &&
-                    currentTracklist[songIndex].songSource}
-                playing={playing}
-                played={localPlayback.played}
-                volume={volume / VOLUME_MAX}
-                onProgress={updateProgress}
-                onEnded={nextTrack}
-                onDuration={getDuration}
-            />
+            {
+                hasNonEmptyTracklist() &&
+                hasValidSongIndex() &&
+                <ReactPlayer
+                    height="0"
+                    ref={getPlayer}
+                    url={currentTracklist[songIndex].songSource}
+                    playing={playing}
+                    played={localPlayback.played}
+                    volume={volume / VOLUME_MAX}
+                    onProgress={updateProgress}
+                    onEnded={nextTrack}
+                    onDuration={getDuration}
+                />
+            }
         </>
     )
 }

--- a/frontend/src/components/Main-window.jsx
+++ b/frontend/src/components/Main-window.jsx
@@ -22,7 +22,7 @@ const debug = false;
 
 function Main() {
   const { theme, mode } = useContext(ThemeContext);
-  const { userPlaylistSpotify, currentPlayingSongData, logout, userProfileSpotify } = useContext(Context);
+  const { userPlaylistSpotify, currentPlayingSongData, userProfileSpotify } = useContext(Context);
   const [localPlaylistsState, setLocalPlaylistsState] = useState([]);
 
   const {

--- a/frontend/src/components/Player.jsx
+++ b/frontend/src/components/Player.jsx
@@ -13,7 +13,9 @@ function Player() {
   const {
     songIndex,
     setSongIndex,
-    currentTracklist
+    currentTracklist,
+    hasNonEmptyTracklist,
+    hasValidSongIndex
   } = useContext(MusicPlayerStateContext);
   const { accessToken, getSongAudioAnalysis } = useContext(Context);
   const { volume, VOLUME_MAX } = useContext(SettingsStateContext);
@@ -84,7 +86,6 @@ function Player() {
     }
   }, [theme, mode])
 
-
   // Updates the songIndex as the user uses the previous and next buttons
   // on the react spotify player, properly updating the songCards in the
   // playlistContainer. Also grabs audio analaysis from the playback
@@ -129,8 +130,8 @@ function Player() {
   return (
     <div className="d-flex justify-content-center flex-column align-items-center h-100">
       {
-        currentTracklist &&
-        currentTracklist.length > 0 &&
+        hasNonEmptyTracklist() &&
+        hasValidSongIndex() &&
         typeof currentTracklist[0] === "string" &&
         <SpotifyPlayer
           name={PLAYER_NAME}

--- a/frontend/src/components/PlaylistControls.css
+++ b/frontend/src/components/PlaylistControls.css
@@ -1,3 +1,47 @@
 #local-playlist-controls-body {
     min-height: 350px;
 }
+
+/* 
+ * nav-links styled separately with important tags to
+ * override bootstrap styling
+ */
+.nav-link-royal-light {
+    background-color: #fafafa !important;
+    color: #323130 !important;
+}
+
+.nav-link-royal-light.active {
+    background-color: #5CADF8 !important;
+    color: #fafafa !important;
+}
+
+.nav-link-royal-dark {
+    background-color: #0E0F3B !important;
+    color: #fafafa !important;
+}
+
+.nav-link-royal-dark.active {
+    background-color: #22238D !important;
+    color: #fafafa !important;
+}
+
+.nav-link-bvt-light {
+    background-color: #FD2C00 !important;
+    color: #fafafa !important;
+}
+
+.nav-link-bvt-light.active {
+    background-color: #FF5531 !important;
+    color: #fafafa !important;
+}
+
+.nav-link-bvt-dark {
+    background-color: #737873 !important;
+    color: #fafafa !important;
+}
+
+.nav-link-bvt-dark.active {
+    background-color: #FF5531 !important;
+    color: #fafafa !important;
+}

--- a/frontend/src/components/PlaylistControls.jsx
+++ b/frontend/src/components/PlaylistControls.jsx
@@ -254,7 +254,7 @@ const PlaylistControls = ({ setLocalPlaylistsState, fetchLocalPlaylists }) => {
                   aria-orientation="vertical"
                 >
                   <button
-                    className="nav-link active"
+                    className={`nav-link active nav-link-${theme}-${mode}`}
                     id="v-pills-create-tab"
                     onClick={() => handleChangeActiveTab("create")}
                     data-bs-toggle="pill"
@@ -267,7 +267,7 @@ const PlaylistControls = ({ setLocalPlaylistsState, fetchLocalPlaylists }) => {
                     Create Local Playlist
                   </button>
                   <button
-                    className="nav-link"
+                    className={`nav-link nav-link-${theme}-${mode}`}
                     id="v-pills-edit-tab"
                     onClick={() => handleChangeActiveTab("edit")}
                     data-bs-toggle="pill"

--- a/frontend/src/components/popover.css
+++ b/frontend/src/components/popover.css
@@ -25,6 +25,7 @@
 .volume, .bass, .treble {
     transform: rotate(270deg);
     width: 80px;
+    margin-right: .5rem;
 }
 
 .volume-component, .equalizer-component{
@@ -63,4 +64,9 @@
     position: absolute;
     white-space: nowrap;
     width: 1px;
+}
+
+input[type=number] {
+    border-radius: 0.375rem;
+    min-width: 3rem;
 }

--- a/frontend/src/contexts/MusicPlayerStateContext.jsx
+++ b/frontend/src/contexts/MusicPlayerStateContext.jsx
@@ -57,11 +57,18 @@ function MusicPlayerStateContextProvider({ children }) {
      * @param {Number} index The index of a playlist in the library
      */
     function choosePlaylist(index) {
+        // Delay when the song index is updated such that the
+        // SpotifyPlayer start playback immediately upon 
+        // songIndex change
+        const SONG_INDEX_UPDATE_DELAY = 250
+
         // Only change playlist index and reset song index when given
         // a new songIndex
+        setPlaylistIndex(index)
         if (index !== playlistIndex) {
-            setSongIndex(0)
-            setPlaylistIndex(index)
+            setTimeout(() => {
+                setSongIndex(0)
+            }, SONG_INDEX_UPDATE_DELAY)
         }
 
         // Only allow user to go to playlist view on mobile
@@ -79,7 +86,6 @@ function MusicPlayerStateContextProvider({ children }) {
         setSongIndex(index)
     }
 
-
     /**
      * Sets the library view as true. Meant to be used as event listener
      * for window size, such that if a user resizes their window to be
@@ -90,6 +96,18 @@ function MusicPlayerStateContextProvider({ children }) {
             window.innerWidth >= MEDIUM_SCREEN_BREAKPOINT) {
             setLibraryView(true)
         }
+    }
+
+    /**
+     * For use of the Player variables to check whether or not
+     * to load based on if the songIndex is in a valid index
+     * for the currentTracklist
+     * @returns {bool} Whether or not the songIndex state is
+     * in the valid range of the currentTracklist
+     */
+    function hasValidSongIndex() {
+        return songIndex >= 0 &&
+            songIndex < currentTracklist.length
     }
 
     // PLAYER CONTROL FUNCTIONS
@@ -214,7 +232,7 @@ function MusicPlayerStateContextProvider({ children }) {
             songImage: ""
         }
 
-        if (hasNonEmptyTracklist()) {
+        if (hasNonEmptyTracklist() && hasValidSongIndex()) {
             const currentSong = currentTracklist[songIndex]
 
             songMetadata.artist = currentSong.artist
@@ -257,7 +275,8 @@ function MusicPlayerStateContextProvider({ children }) {
                 duration,
                 convertToTimestamp,
                 getCurrentSongMetadata,
-                player
+                player,
+                hasValidSongIndex
             }}
         >
             {children}


### PR DESCRIPTION
## Changes
1. Addressed bug that caused Spotify playback to sometimes occur when the user clicked on a local playlist while they were playing a Spotify playlist.
2. Did miscellaneous styling on the EQ and Volume Controls and the PlaylistControls modal for design consistency.
3. Refactored the CurrentSong to use bootstrap's offcanvas controls on the left side of the container rather than the whole container using CSS pointer events.

## Purpose
When the user would click on a local playlist while they were playing a Spotify playlist that wasn't currently playing the first song, playback of the Spotify playlist would continue even while the app would display the local playlist.

Before, the EQ and Volume controls' number inputs were styled different from other inputs and the PlaylistControls' nav pills stylings did not account for the theme or mode.

The CurrentSong initially used bootstrap controls on the music buttons such that they would dismiss the CurrentSongOffCanvas, because otherwise the click of them would propagate such that the current-song-container would detect a child element being clicked and bring up the CurrentSongOffCanvas. Doing this however would trigger errors in the console as bootstrap controls are not meant to be called without a target.

## Approach
The Spotify playback bug was addressed by adding a delay when updating the songIndex when the choosePlaylist function was used. This makes it so we can add an extra check to the Player components to only render them/start their playback when a valid songIndex was being used, which prevents Spotify playback from continuing after the user selects a local playlist.

By styling the EQ/Volume Controls and the PlaylistControl's modal, we improve the UI by making their designs more uniform with the rest of the app.

By refactoring the CurrentSong's playlist controls to rely more on CSS rather the bootstrap controls, we can avoid the this._config errors that would trigger when pressing a music button.

## Learning
Some light reading of the [react-spotify-web-playback code](https://github.com/gilbarbara/react-spotify-web-playback) and our own code was done to understand why the bug was occurring.

And reading of the [documentation on CSS pointer-events](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) and [example cases of usage](https://stackoverflow.com/questions/39374918/on-hover-of-child-change-background-color-of-parent-container-css-only) was done to refactor the music-buttons and CurrentSong controls for the CurrentSongOffCanvas.

## Preview
![image](https://github.com/missile720/music-player/assets/45379337/6927810e-1c2b-415e-8a0b-b35c59cba0f8)
*Nav pills on the PlaylistControls modal now account for theme and mode*

![image](https://github.com/missile720/music-player/assets/45379337/4dc3b853-93b9-415e-a446-4286dd839888)
![image](https://github.com/missile720/music-player/assets/45379337/33e6789f-3aa9-4a7f-9631-69341e0c5ec5)
*Popover elements now have number inputs that can display their full values and are more in line with design*

Closes #132 
