### PR TITLE
fix(bug): Addressed a bug with the LocalMusicPlayer after fixing Chrome CORS issue that broke the EQ implementation

### DIFF
--- a/frontend/src/components/CurrentSong.css
+++ b/frontend/src/components/CurrentSong.css
@@ -36,6 +36,10 @@ li {
   pointer-events: all;
 }
 
+.custom-range {
+  pointer-events: all;
+}
+
 .music-button {
   cursor: pointer;
   width: 30px;

--- a/frontend/src/components/LogoutPrompt.jsx
+++ b/frontend/src/components/LogoutPrompt.jsx
@@ -41,12 +41,12 @@ const LogoutPrompt = () => {
                     <div className="modal-footer">
                         <button
                             type="button"
-                            class={`btn element-${theme}-${mode}`}
+                            className={`btn element-${theme}-${mode}`}
                             data-bs-dismiss="modal"
                         >Cancel</button>
                         <button
                             type="button"
-                            class={`btn element-${theme}-${mode}`}
+                            className={`btn element-${theme}-${mode}`}
                             onClick={() => logout()}
                             data-bs-dismiss="modal"
                         >Logout</button>

--- a/frontend/src/contexts/SettingsStateContext.jsx
+++ b/frontend/src/contexts/SettingsStateContext.jsx
@@ -30,7 +30,11 @@ trebleFilter.connect(bassFilter)
 
 const SettingsStateContextProvider = ({ children }) => {
     // Context Values
-    const { currentSongSource, player } = useContext(MusicPlayerStateContext)
+    const {
+        currentSongSource,
+        player,
+        currentTracklist
+    } = useContext(MusicPlayerStateContext)
 
     // States
     const [volume, setVolume] = useState(50)
@@ -53,11 +57,9 @@ const SettingsStateContextProvider = ({ children }) => {
                     // Stores and resets the original src attribute of the
                     // audio in order to have the crossorigin anonymous
                     // attribute set when creating the element stream
-                    const originalSrc = audio.getAttribute("src")
-
                     audio.setAttribute("src", "")
                     audio.setAttribute("crossorigin", "anonymous")
-                    audio.setAttribute("src", originalSrc)
+                    audio.setAttribute("src", currentTracklist[0].songSource)
 
                     setAudioSource(audio)
                 }
@@ -66,7 +68,8 @@ const SettingsStateContextProvider = ({ children }) => {
             }, AUDIO_SOURCE_UPDATE_DELAY)
 
         }
-    }, [currentSongSource, player])
+    }, [currentSongSource, player, player && player.getInternalPlayer()])
+
 
     /**
      * Effect to connect the audioSource to the equalizer when


### PR DESCRIPTION
## Changes
1. Added to the SettingsStateContext's logic for updating the audioSource the ReactPlayer's internal as a useEffect dependency.
2. Added pointer events back onto the progress bar on the CurrentSong such that the able is able to use it

## Purpose
To address a bug after the Chrome CORS issue push that disabled the EQ implementation from working with the player.

## Approach
After some debugging I noticed that with the new logic for handling the CORS issue created a new instance of a video element to play the music, which did not update the audioSource to connect with the biquadfilters used for the EQ implementation. To address this, the ReactPlayer's internal player was added as a dependency for updating the biquadFilter's targets, such that the user is able to use the EQ functionality on their local playlists.

Closes #141
