### PR TITLE
fix(bug): Fixed issue of app sometimes loading songs with incorrect crossorigin headers on Chrome

### DIFF
--- a/frontend/src/components/LocalMusicPlayer.jsx
+++ b/frontend/src/components/LocalMusicPlayer.jsx
@@ -10,6 +10,7 @@ import CurrentSong from "./CurrentSong"
 const DUMMY_MP3_URL = "https://bvt-music-player.s3.us-west-1.amazonaws.com/01_Sam_Rudich.mp3"
 
 const LocalMusicPlayer = () => {
+    // Context Variables
     const {
         playing,
         localPlayback,
@@ -28,6 +29,8 @@ const LocalMusicPlayer = () => {
         audioSource
     } = useContext(SettingsStateContext)
 
+    // State Variables
+    // Indicates if ReactPlayer internal player is loaded with crossorigin header
     const [loaded, setLoaded] = useState(false)
 
     /**
@@ -40,6 +43,20 @@ const LocalMusicPlayer = () => {
         }
     }, [audioSource])
 
+    /**
+     * A fix to address the Chrome issue of caching calls, as without this the app
+     * would sometimes load the first songs of playlists without the crossorigin 
+     * attribute
+     * @returns {string} The url of the current song to play on the Amazon backend
+     */
+    function getCurrentSong() {
+        if (songIndex !== 0 && audioSource.getAttribute("crossorigin")) {
+            return currentTracklist[songIndex].songSource
+        } else {
+            return currentTracklist[0].songSource
+        }
+    }
+
     return (
         <>
             <CurrentSong />
@@ -49,7 +66,7 @@ const LocalMusicPlayer = () => {
                 <ReactPlayer
                     height="0"
                     ref={getPlayer}
-                    url={loaded ? currentTracklist[songIndex].songSource
+                    url={loaded ? getCurrentSong()
                         : DUMMY_MP3_URL}
                     playing={playing}
                     played={localPlayback.played}

--- a/frontend/src/contexts/SettingsStateContext.jsx
+++ b/frontend/src/contexts/SettingsStateContext.jsx
@@ -77,6 +77,7 @@ const SettingsStateContextProvider = ({ children }) => {
      */
     useEffect(() => {
         if (audioSource && Object.keys(audioSource).length) {
+            console.log(audioContext)
             const source = audioContext.createMediaElementSource(audioSource)
             source.connect(trebleFilter)
         }

--- a/frontend/src/contexts/SettingsStateContext.jsx
+++ b/frontend/src/contexts/SettingsStateContext.jsx
@@ -41,6 +41,7 @@ const SettingsStateContextProvider = ({ children }) => {
     const [bass, setBass] = useState(0)
     const [treble, setTreble] = useState(0)
     const [audioSource, setAudioSource] = useState({})
+    const [audioSourceNode, setAudioSourceNode] = useState(null)
 
     // Effects 
     /**
@@ -77,9 +78,16 @@ const SettingsStateContextProvider = ({ children }) => {
      */
     useEffect(() => {
         if (audioSource && Object.keys(audioSource).length) {
-            console.log(audioContext)
+            // Disconnects the previous audioSourceNode to prevent
+            // multiple audio source nodes from chaining to the 
+            // biquadFilters
+            if (audioSourceNode) {
+                audioSourceNode.disconnect()
+            }
+
             const source = audioContext.createMediaElementSource(audioSource)
             source.connect(trebleFilter)
+            setAudioSourceNode(source)
         }
     }, [audioSource])
 


### PR DESCRIPTION
## Changes
1. Created a getter to load which URL gets loaded into ReactPlayer during local playlist playback
2. Refactored SettingsStateContext to have a state for the audioSourceNode

## Purpose
To address a specific Chrome bug of when a user changes from one local playlist to another after the initial ReactPlayer crossorigin setting and load, where the app would load the song using the initial resource request without the crossorigin header rather than the one with it, cause the app to not play that song.

## Approach
This change addresses that problem by creating a getter that has extra logic for choosing which URL to load, which by passes the way Chrome caches and chooses which elements to load.

The SettingsStateContext was also implemented to now have an audioSourceNode state, such that when the app loads and has to connect a new audioSource to the biquadFilters, the source of the audio for those filters will only ever come from one node.

Closes #144 
