### PR TITLE
fix(delete popup): The delete popup now follows the theme

### DIFF
--- a/frontend/src/components/PlaylistControls.jsx
+++ b/frontend/src/components/PlaylistControls.jsx
@@ -230,7 +230,7 @@ const PlaylistControls = () => {
         aria-hidden="true"
       >
         <div className="modal-dialog">
-          <div className="modal-content">
+          <div className={`modal-content primary-${theme}-${mode}`}>
             <div className="modal-header">
               <h1 className="modal-title fs-5">Delete Playlist</h1>
               <button


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Fixes issue with delete popup not following the theme

## Purpose
Delete popup follows the theme

## Approach
User can now read the text on popup

## Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #150 
