### PR TITLE
feat(edit-indication): Indicates to user that an edit to their library is in progress by disabling the PlaylistControls button toggle

### DIFF
--- a/frontend/src/components/Main-window.jsx
+++ b/frontend/src/components/Main-window.jsx
@@ -22,7 +22,14 @@ const debug = false;
 
 function Main() {
   const { theme, mode } = useContext(ThemeContext);
-  const { userPlaylistSpotify, currentPlayingSongData, userProfileSpotify, fetchLocalPlaylists, localPlaylistsState, updateLocalPlaylists } = useContext(Context);
+  const {
+    userPlaylistSpotify,
+    currentPlayingSongData,
+    userProfileSpotify,
+    fetchLocalPlaylists,
+    localPlaylistsState,
+    updateLocalPlaylists,
+  } = useContext(Context);
 
   const {
     library,
@@ -32,6 +39,7 @@ function Main() {
     setLibraryView,
     currentSongSource,
     getPlaylistName,
+    updating,
   } = useContext(MusicPlayerStateContext);
 
   // Load the user's playlists from Spotify and their uploaded playlists  
@@ -80,6 +88,7 @@ function Main() {
               className={`btn element-${theme}-${mode}`}
               data-bs-toggle="modal"
               data-bs-target="#file-upload"
+              disabled={updating}
             >
               Playlist Controls
             </button>

--- a/frontend/src/components/PlaylistControls.jsx
+++ b/frontend/src/components/PlaylistControls.jsx
@@ -13,11 +13,18 @@ const PlaylistControls = () => {
   const [selectedPlaylistSource, setSelectedPlaylistSource] = useState("");
   const [activeTab, setActiveTab] = useState("create");
 
-  const { library, playlistIndex, choosePlaylist } = useContext(
-    MusicPlayerStateContext
-  );
+  const {
+    library,
+    playlistIndex,
+    choosePlaylist,
+    setUpdating,
+  } = useContext(MusicPlayerStateContext);
   const { theme, mode } = useContext(ThemeContext);
-  const { updatePlaylistName, userProfileSpotify, updateLocalPlaylists } = useContext(Context);
+  const {
+    updatePlaylistName,
+    userProfileSpotify,
+    updateLocalPlaylists
+  } = useContext(Context);
 
   const [playlistData, setPlaylistData] = useState({});
 
@@ -135,6 +142,7 @@ const PlaylistControls = () => {
             }),
           }
         );
+        setUpdating(true)
         await updateLocalPlaylists();
       } catch (error) {
         console.log({ "Error editing playlist": error });
@@ -370,6 +378,7 @@ const PlaylistControls = () => {
                 form="file-upload"
                 className={`btn element-${theme}-${mode}`}
                 data-bs-dismiss="modal"
+                onClick={() => setUpdating(true)}
               >
                 Submit
               </button>

--- a/frontend/src/contexts/MusicPlayerStateContext.jsx
+++ b/frontend/src/contexts/MusicPlayerStateContext.jsx
@@ -24,6 +24,7 @@ function MusicPlayerStateContextProvider({ children }) {
     })
     const [player, setPlayer] = useState(() => { })
     const [duration, setDuration] = useState(0)
+    const [updating, setUpdating] = useState(false)
 
     // Effects
     /**
@@ -48,6 +49,13 @@ function MusicPlayerStateContextProvider({ children }) {
             setCurrentSongSource(library[playlistIndex].source ? 'local' : 'spotify')
         }
     }, [songIndex, playlistIndex, library])
+
+    /**
+     * Updating 
+     */
+    useEffect(() => {
+        setUpdating(false)
+    }, [library])
 
     // Functions
     /**
@@ -276,7 +284,9 @@ function MusicPlayerStateContextProvider({ children }) {
                 convertToTimestamp,
                 getCurrentSongMetadata,
                 player,
-                hasValidSongIndex
+                hasValidSongIndex,
+                updating,
+                setUpdating
             }}
         >
             {children}

--- a/frontend/src/contexts/MusicPlayerStateContext.jsx
+++ b/frontend/src/contexts/MusicPlayerStateContext.jsx
@@ -51,7 +51,8 @@ function MusicPlayerStateContextProvider({ children }) {
     }, [songIndex, playlistIndex, library])
 
     /**
-     * Updating 
+     * Sets updating variable to false after library has finished refreshing after 
+     * an update has been made.
      */
     useEffect(() => {
         setUpdating(false)


### PR DESCRIPTION
## Changes
1. Disabled button to toggle PlaylistControls when user makes a change to their library from the PlaylistControls modal

## Purpose
To improve UX by giving the user some kind of indication that an edit they've made from the PlaylistControls is currently being processed

## Approach
By disabling the PlaylistControls button when the user performs an edit to their library from it, we improve UX by not only disallowing them from spamming edit requests to the library when they make an expensive request that doesn't immediately give them feedback, we also give a sign to the user that the edit request is being processed through the visual indication of the button being disabled.

## Preview
![image](https://github.com/missile720/music-player/assets/45379337/27e29880-2be9-4144-9eac-30beb9006d91)
*After sending in an edit request, the PlaylistButton visually indicates it is disabled, indicating to the user that their edit is currently being processed. This allows prevents the user from trying to make another edit request when they don't get immediate feedback from their request being made*

Closes #152 
