### PR TITLE
149 reset playlist control inputs on submit

### DIFF
--- a/frontend/src/components/CreatePlaylist.jsx
+++ b/frontend/src/components/CreatePlaylist.jsx
@@ -1,17 +1,6 @@
 const CreatePlaylist = ({ playlistData, handlePlaylistChangeName, handlePlaylistCoverChange, handleSongMetaData }) => {
     return (
         <>
-            <div className="mb-3">
-                <span id="inputGroup-sizing-default">Playlist Cover Image</span>
-                <input
-                    type="file"
-                    className="form-control"
-                    aria-label="Sizing example input"
-                    aria-describedby="inputGroup-sizing-default"
-                    onChange={handlePlaylistCoverChange}
-                    accept="image/*"
-                />
-            </div>
             <div className=" mb-3">
                 <span id="inputGroup-sizing-default">Playlist Name</span>
                 <input
@@ -23,6 +12,19 @@ const CreatePlaylist = ({ playlistData, handlePlaylistChangeName, handlePlaylist
                     onChange={handlePlaylistChangeName}
                 />
             </div>
+
+            <div className="mb-3">
+                <span id="inputGroup-sizing-default">Playlist Cover Image</span>
+                <input
+                    type="file"
+                    className="form-control"
+                    aria-label="Sizing example input"
+                    aria-describedby="inputGroup-sizing-default"
+                    onChange={handlePlaylistCoverChange}
+                    accept="image/*"
+                />
+            </div>
+
             <div className="mb-3">
                 <span id="inputGroup-sizing-default">Songs</span>
                 <input

--- a/frontend/src/components/EditPlaylists.jsx
+++ b/frontend/src/components/EditPlaylists.jsx
@@ -5,7 +5,7 @@ const EditPlaylists = ({
   handleSongMetaData,
   handleSelectionChange,
   selectedPlaylistSource,
-  library,
+  library
 }) => {
   const playlistsToEditOptions = library.map((playlist) => (
     <option key={playlist.id} value={playlist.id}>

--- a/frontend/src/components/EditPlaylists.jsx
+++ b/frontend/src/components/EditPlaylists.jsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 const EditPlaylists = ({
   playlistData,
   handlePlaylistChangeName,
@@ -5,8 +7,10 @@ const EditPlaylists = ({
   handleSongMetaData,
   handleSelectionChange,
   selectedPlaylistSource,
-  library
+  library,
+  formRef
 }) => {
+
   const playlistsToEditOptions = library.map((playlist) => (
     <option key={playlist.id} value={playlist.id}>
       {playlist.name}
@@ -21,8 +25,9 @@ const EditPlaylists = ({
           className="form-select"
           data-live-search="true"
           onChange={handleSelectionChange}
+          ref={formRef}
         >
-          <option value="none" selected disabled hidden>
+          <option value="" selected disabled hidden>
             Select an Option
           </option>
           {playlistsToEditOptions}

--- a/frontend/src/components/PlaylistControls.jsx
+++ b/frontend/src/components/PlaylistControls.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from "react";
+import { useState, useContext, useEffect, useRef } from "react";
 import { Context } from "../contexts/Context";
 import { MusicPlayerStateContext } from "../contexts/MusicPlayerStateContext";
 import { ThemeContext } from "../contexts/ThemeContext";
@@ -20,6 +20,7 @@ const PlaylistControls = () => {
   const { updatePlaylistName, userProfileSpotify, updateLocalPlaylists } = useContext(Context);
 
   const [playlistData, setPlaylistData] = useState({});
+  const formRef = useRef(null);
 
   useEffect(() => {
     resetInputs();
@@ -217,6 +218,8 @@ const PlaylistControls = () => {
         updatePlaylistName(selectedPlaylistId, playlistData.name);
       }
     }
+    resetInputs();
+    formRef.current.reset();
   }
 
   return (
@@ -275,12 +278,13 @@ const PlaylistControls = () => {
         aria-labelledby="file-upload-modal"
         aria-hidden="true"
         onSubmit={handleSubmit}
+        ref={formRef}
       >
         <div className="modal-dialog">
           <div className={`modal-content primary-${theme}-${mode}`}>
             <div className="modal-header">
               <h5 className="modal-title" id="exampleModalLabel">
-                Local Playlist Controls
+                Playlist Controls
               </h5>
               <button
                 type="button"
@@ -308,7 +312,7 @@ const PlaylistControls = () => {
                     aria-controls="v-pills-create"
                     aria-selected="true"
                   >
-                    Create Local Playlist
+                    Create a Playlist
                   </button>
                   <button
                     className={`nav-link nav-link-${theme}-${mode}`}
@@ -321,7 +325,7 @@ const PlaylistControls = () => {
                     aria-controls="v-pills-edit"
                     aria-selected="false"
                   >
-                    Edit Local Playlists
+                    Edit Playlists
                   </button>
                 </div>
                 <div className="tab-content" id="v-pills-tabContent">

--- a/frontend/src/components/PlaylistControls.jsx
+++ b/frontend/src/components/PlaylistControls.jsx
@@ -37,7 +37,7 @@ const PlaylistControls = () => {
         }
       }
     }
-  }, [selectedPlaylistId]);
+  }, [selectedPlaylistId, library]);
 
   function handleChangeActiveTab(tabName) {
     setActiveTab(tabName);
@@ -136,11 +136,14 @@ const PlaylistControls = () => {
             }),
           }
         );
+        formRef.current.reset();
+        setSelectedPlaylistSource("");
         await updateLocalPlaylists();
       } catch (error) {
         console.log({ "Error editing playlist": error });
       }
     }
+
   }
 
   function handlePlaylistCoverChange(event) {
@@ -356,6 +359,7 @@ const PlaylistControls = () => {
                       handleSelectionChange={handleSelectionChange}
                       selectedPlaylistSource={selectedPlaylistSource}
                       library={library}
+                      formRef={formRef}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Playlist control inputs now reset on submit.
2. Selected option on edit playlist now resets after deleting a playlist.

## Purpose
Inputs in playlist controls were not resetting after submitting a playlist change.

## Approach
I used a useRef to reset the form inputs after the form is submitted. I also utilized our setSelectedPlaylistSource to set the selected option to the default value after deleting a playlist.

## Learning
I learned how to use useRef.

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #149 
